### PR TITLE
안드로이드 이미지 피커 버전 업데이트

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.github.classtinginc:android-image-picker:1.1.4'
+    implementation 'com.github.classtinginc:android-image-picker:1.1.5'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.github.yalantis:ucrop:2.2.6-native'
     implementation 'com.google.code.gson:gson:2.8.3'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-image-crop-picker",
-  "version": "0.37.3-ct.2",
+  "version": "0.37.3-ct.3",
   "description": "Select single or multiple images, with cropping option",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
heic 이미지 형식 변환 로직에 exif 로테이션 유지 작업을 포함한 android-image-picker 1.1.5 버전이 반영되었습니다.

ref [4123](https://github.com/classtinginc/classting-rn/issues/4123)