### PR TITLE
chore: android-image-picker 버전을 1.1.13 으로 업데이트

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.github.classtinginc:android-image-picker:1.1.9'
+    implementation 'com.github.classtinginc:android-image-picker:1.1.13'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.github.yalantis:ucrop:2.2.6-native'
     implementation 'com.google.code.gson:gson:2.8.3'


### PR DESCRIPTION
android-image-picker 업데이트된 버전 변경 사항
- 이미지 선택 화면에서 권한을 요청하지 않습니다.
- 이미지 피커 로직에서 return 되는 Intent의 data 값을 Image 클래스의 모든 attribute 가 직렬화된 값으로 변경
- return 되는 값을 확인할 수 있도록 로그 추가