### PR TITLE
chore: bump android-image-picker verion to 1.1.24

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.github.classtinginc:android-image-picker:1.1.13'
+    implementation 'com.github.classtinginc:android-image-picker:1.1.24'
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'
     implementation 'com.github.yalantis:ucrop:2.2.6-native'
     implementation 'com.google.code.gson:gson:2.8.3'


### PR DESCRIPTION
android-image-picker 버전을 1.11.3 에서 1.1.24로 업데이트하였습니다.