### PR TITLE
TOCropViewController 최소 버전 변경

### DIFF
--- a/RNImageCropPicker.podspec
+++ b/RNImageCropPicker.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "8.0"
   s.dependency 'React-Core'
   s.dependency 'React-RCTImage'
-  s.dependency 'TOCropViewController', '~> 2.7.3'
+  s.dependency 'TOCropViewController', '~> 2.7.4'
   s.resource_bundles = {
     'RNImageCropPickerPrivacyInfo' => ['ios/PrivacyInfo.xcprivacy'],
   }


### PR DESCRIPTION
Privacy Manifest 관련 문제를 해결한 버전으로 최소버전을 업데이트 합니다.

참고 : https://github.com/TimOliver/TOCropViewController/issues/592