### PR TITLE
이미지 회전 속성 확인 후 올바른 width, height 반환

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -11,6 +11,7 @@ import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
+import android.media.ExifInterface;
 import android.media.MediaMetadataRetriever;
 import android.net.Uri;
 import android.os.Build;
@@ -715,9 +716,24 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
         BitmapFactory.Options options = validateImage(activity, compressedImagePath);
         long modificationDate = new File(path).lastModified();
 
+        int height = options.outHeight;
+        int width = options.outWidth;
+
+        // 이미지가 90도 또는 270도로 회전된 경우 width와 height를 교환한다.
+        ExifInterface originalExif = new ExifInterface(path);
+        int orientation = originalExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL);
+        if (orientation == ExifInterface.ORIENTATION_ROTATE_90 ||
+                orientation == ExifInterface.ORIENTATION_ROTATE_270 ||
+                orientation == ExifInterface.ORIENTATION_TRANSPOSE ||
+                orientation == ExifInterface.ORIENTATION_TRANSVERSE) {
+            int temp = width;
+            width = height;
+            height = temp;
+        }
+
         image.putString("path", "file://" + compressedImagePath);
-        image.putInt("width", options.outWidth);
-        image.putInt("height", options.outHeight);
+        image.putInt("width", width);
+        image.putInt("height", height);
         image.putString("mime", options.outMimeType);
         image.putInt("size", (int) new File(compressedImagePath).length());
         image.putString("modificationDate", String.valueOf(modificationDate));


### PR DESCRIPTION
**이슈 원인**
이미지의 `width`와 `height`를 읽을 때, 이미지의 `Orientation`에 따라 실제 이미지의 가로와 세로가 변경될 수 있습니다. `Orientation`이 90도 또는 270도일 경우, `width`와 `height` 값이 반대로 출력됩니다. 

`stream-chat-react-native`에서는 `react-native-image-crop-picker`에서 반환된 width와 height 값을 기준으로 영역을 계산하기 때문에, `Orientation`이 90도 또는 270도인 이미지들이 비정상적인 사이즈로 랜더링됩니다.

**해결 방법**
`Orientation`이 90도 또는 270일 경우 `width`와 `height` 를 바꾸어서 리턴한다.

**테스트 케이스**
`classting-rn` 레포에서 `package.json` 을 수정하여 테스트할 수 있음
```
"react-native-image-crop-picker": "github:classtinginc/react-native-image-crop-picker#v0.41.2-ct.5-rc.1"
```

- [ ] 90, 180, 270 회전해가며 사진을 찍고 업로드했을 때 스트림챗 메세지 버블에 정상적인 영역을 차지한다.
- [ ] 카메라 배율(3:4, 9:16, 1:1, Full) 에 따른 사진을 찍고 업로드했을 때 스트림챗 메세지 버블에 정상적인 영역을 차지한다.

**참고**
Orientation [문서](https://developer.android.com/reference/androidx/exifinterface/media/ExifInterface?hl=en&_gl=1*avuc7n*_up*MQ..*_ga*MTE0NDIzMzY5Ni4xNzQyOTY3NzM5*_ga_6HH9YJMN9M*MTc0Mjk2NzczOS4xLjAuMTc0Mjk2NzczOS4wLjAuMTk0MzU1MDQ0Nw..#TAG_ORIENTATION())
