### PR TITLE
getAsyncSelection를 비동기 처리하도록 수정함

### DIFF
--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
@@ -535,7 +535,16 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
             return;
         }
 
-        resultCollector.notifySuccess(getImage(activity, path));
+        new Thread(() -> {
+            try {
+                WritableMap image = getImage(activity, path);
+                activity.runOnUiThread(() -> resultCollector.notifySuccess(image));
+            } catch (Exception e) {
+                // 실패한 처리에 대해서는 무시하고 비동기 처리를 종료하기 위해 waitCounter를 증가시킴
+                resultCollector.addWaitCount();
+                Log.e("image-crop-picker", "getImage failed in getAsyncSelection" + e);
+            }
+        }).start();
     }
 
     private Bitmap validateVideo(String path) throws Exception {

--- a/android/src/main/java/com/reactnative/ivpusic/imagepicker/ResultCollector.java
+++ b/android/src/main/java/com/reactnative/ivpusic/imagepicker/ResultCollector.java
@@ -93,4 +93,8 @@ class ResultCollector {
         promise.reject(code, throwable);
         resultSent = true;
     }
+
+    synchronized void addWaitCount() {
+        waitCounter.addAndGet(1);
+    }
 }


### PR DESCRIPTION
- 이미지 피커에서 파일 선택 후 getAsyncSelection에서 getImage 과정을 비동기로 처리하지 않아 ANR이 발생하는 경우가 있어, 백그라운드 스레드에서 처리하도록 변경함